### PR TITLE
Fix possible flaky food_catcher tests by seeding random

### DIFF
--- a/colosseum/games/food_catcher/tests/conftest.py
+++ b/colosseum/games/food_catcher/tests/conftest.py
@@ -1,0 +1,8 @@
+import random
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def fixed_random_seed():
+    """keeps tests that use random number generation reproducible."""
+    random.seed(42)


### PR DESCRIPTION
Hey, this is part of a research project on test reliability in open source Python projects.

`Food.__init__` calls `random.uniform` to set the initial quantity, and `World` also calls `uniform` and `shuffle` in several places during initialization and gameplay. Without a fixed seed, any test that instantiates these classes can produce different values on each run, which can make assertions fragile.

Added a `conftest.py` with an `autouse` fixture that sets `random.seed(42)` before each test in the `food_catcher` test suite. No test files were modified (the fixture applies automatically to the whole directory).